### PR TITLE
Testing for stringify.js

### DIFF
--- a/test/stringify.js
+++ b/test/stringify.js
@@ -126,6 +126,18 @@ test('array stringify representation with array commas', t => {
 	}), 'bar=one,two&foo');
 });
 
+test('array stringify representation with array commas and null/empty values', t => {
+    const result = queryString.stringify({
+        list: ['item', null, 'last', '']
+    }, {
+        arrayFormat: 'comma',
+        skipNull: false,
+        skipEmptyString: false
+    });
+
+    t.is(result, 'list=item,,last,');
+});
+
 test('array stringify representation with array commas and null value', t => {
 	t.is(queryString.stringify({
 		foo: [null, 'a', null, ''],


### PR DESCRIPTION
This PR adds test to cover a bug in stringify function when handling null and empty string values with arrayFormat:'comma'
Test case currently says that the function skips these values even when skipNull and skipEmptyString are set to false. Expected output shouldn't skip them and replace them with commas.